### PR TITLE
Upgrade for io.dropwizard artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <!-- DropWizard -->
         <dependency>
-            <groupId>com.codahale.dropwizard</groupId>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
@@ -47,4 +47,11 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
 </project>

--- a/src/main/java/com/federecio/dropwizard/junitrunner/DropwizardJunitRunner.java
+++ b/src/main/java/com/federecio/dropwizard/junitrunner/DropwizardJunitRunner.java
@@ -1,6 +1,6 @@
 package com.federecio.dropwizard.junitrunner;
 
-import com.codahale.dropwizard.Application;
+import io.dropwizard.Application;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.InitializationError;

--- a/src/main/java/com/federecio/dropwizard/junitrunner/DropwizardTestConfig.java
+++ b/src/main/java/com/federecio/dropwizard/junitrunner/DropwizardTestConfig.java
@@ -1,6 +1,6 @@
 package com.federecio.dropwizard.junitrunner;
 
-import com.codahale.dropwizard.Application;
+import io.dropwizard.Application;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/test/java/com/federecio/dropwizard/junitrunner/TestApplication.java
+++ b/src/test/java/com/federecio/dropwizard/junitrunner/TestApplication.java
@@ -1,8 +1,8 @@
 package com.federecio.dropwizard.junitrunner;
 
-import com.codahale.dropwizard.Application;
-import com.codahale.dropwizard.setup.Bootstrap;
-import com.codahale.dropwizard.setup.Environment;
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
 
 /**
  * @author Federico Recio

--- a/src/test/java/com/federecio/dropwizard/junitrunner/TestConfig.java
+++ b/src/test/java/com/federecio/dropwizard/junitrunner/TestConfig.java
@@ -1,6 +1,6 @@
 package com.federecio.dropwizard.junitrunner;
 
-import com.codahale.dropwizard.Configuration;
+import io.dropwizard.Configuration;
 
 /**
  * @author Federico Recio


### PR DESCRIPTION
Dropwizard artifacts are now located under "io.dropwizard" Maven groupId.
