### PR TITLE
Update to dropwizard 0.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.federecio</groupId>
     <artifactId>dropwizard-junit</artifactId>
-    <version>0.7</version>
+    <version>0.7-SNAPSHOT</version>
 
     <name>Dropwizard Junit runner</name>
     <description>A JUnit runner to allow testing of Dropwizard applications</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.federecio</groupId>
     <artifactId>dropwizard-junit</artifactId>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.7</version>
 
     <name>Dropwizard Junit runner</name>
     <description>A JUnit runner to allow testing of Dropwizard applications</description>
@@ -42,7 +42,7 @@
         <connection>scm:git:git://github.com:federecio/dropwizard-junit.git</connection>
         <developerConnection>scm:git:git@github.com:federecio/dropwizard-junit.git</developerConnection>
         <url>http://github.com/federecio/dropwizard-junit</url>
-      <tag>HEAD</tag>
+      <tag>dropwizard-junit-0.7</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.federecio</groupId>
     <artifactId>dropwizard-junit</artifactId>
-    <version>0.7</version>
+    <version>0.7-SNAPSHOT</version>
 
     <name>Dropwizard Junit runner</name>
     <description>A JUnit runner to allow testing of Dropwizard applications</description>
@@ -42,7 +42,7 @@
         <connection>scm:git:git://github.com:federecio/dropwizard-junit.git</connection>
         <developerConnection>scm:git:git@github.com:federecio/dropwizard-junit.git</developerConnection>
         <url>http://github.com/federecio/dropwizard-junit</url>
-      <tag>dropwizard-junit-0.7</tag>
+      <tag>HEAD</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.federecio</groupId>
     <artifactId>dropwizard-junit</artifactId>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.7</version>
 
     <name>Dropwizard Junit runner</name>
     <description>A JUnit runner to allow testing of Dropwizard applications</description>
@@ -47,7 +47,7 @@
 
 
     <properties>
-        <dropwizard.version>0.8.0</dropwizard.version>
+        <dropwizard.version>0.8.2</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.7</jdk.version>
     </properties>


### PR DESCRIPTION
In support for [this pull request for dropwizard-swagger](https://github.com/federecio/dropwizard-swagger/pull/67). Need this pull because this package is creating version conflicts with dropwizard-swagger.
